### PR TITLE
FIX/avoid arrow functions in twig

### DIFF
--- a/resources/views/ReinitializePaymentScript.twig
+++ b/resources/views/ReinitializePaymentScript.twig
@@ -35,7 +35,7 @@
     }
 
 
-    document.addEventListener('historyPaymentMethodChanged', e => {
+    document.addEventListener('historyPaymentMethodChanged', function(e) {
         for (let property in e.detail.newOrder.order.properties) {
             if (e.detail.newOrder.order.properties[property].typeId === 3) {
                 if (e.detail.newOrder.order.properties[property].value == {{ paymentMethodId }}) {


### PR DESCRIPTION
Arrow function in twig cause errors in older browser.