### PR TITLE
Change default LayoutContainer for CashInAdvanceReinitializePaymentScript

### DIFF
--- a/src/Assistants/SettingsHandlers/CashInAdvanceSettingsHandler.php
+++ b/src/Assistants/SettingsHandlers/CashInAdvanceSettingsHandler.php
@@ -184,7 +184,7 @@ class CashInAdvanceSettingsHandler implements WizardSettingsHandler
 
             $containerListEntries[] = $this->createContainerDataListEntry(
                 $webstoreId,
-                'Ceres::Script.AfterScriptsLoaded',
+                'Ceres::Checkout.AfterScriptsLoaded',
                 'CashInAdvance\Providers\ReinitializePayment\CashInAdvanceReinitializePaymentScript'
             );
 


### PR DESCRIPTION
Der über den Assistenten gesetzte Standard-Container für CashInAdvanceReinitializePaymentScript wurde von 

Ceres::Script.AfterScriptsLoaded

auf 

Ceres::Checkout.AfterScriptsLoaded

geändert, damit wird unnötiges HTML-DOM außerhalb des Checkout- und MyAccount-Bereiches vermieten. 