### PR TITLE
fix translation of bank detail overlay

### DIFF
--- a/meta/documents/changelog_de.md
+++ b/meta/documents/changelog_de.md
@@ -1,5 +1,9 @@
 # Release Notes für Vorkasse
 
+## 3.0.4 (2020-10-21)
+### Gefixt
+- Das Overlay mit den Bankdaten wird jetzt korrekt übersetzt
+
 ## 3.0.3 (2020-07-15)
 ### Gefixt
 - Assistenten kann wieder abgeschlossen werden

--- a/meta/documents/changelog_en.md
+++ b/meta/documents/changelog_en.md
@@ -1,5 +1,9 @@
 # Release Notes for Cash in advance
 
+## 3.0.4 (2020-10-21)
+### Fixed
+- The overlay with the bank details is now translated correctly
+
 ## 3.0.3 (2020-07-15)
 
 ### Fixed

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-    "version"           : "3.0.3",
+    "version"           : "3.0.4",
     "name"              : "PrePayment",
     "marketplaceName"   : {"de":"Vorkasse","en":"Cash in advance"},
     "license"           : "AGPL-3.0",

--- a/resources/views/BankDetailsOverlay.twig
+++ b/resources/views/BankDetailsOverlay.twig
@@ -4,7 +4,7 @@
     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
         <span aria-hidden="true">x</span>
     </button>
-    <h4 class="modal-title">{{ trans("PrePayment::PaymentMethod.bankDetails") }}</h4>
+    <h4 class="modal-title">{{ trans("PrePayment::PaymentMethod.bankDetails", [], lang) }}</h4>
 </div>
 
 <div class="modal-body form-horizontal">
@@ -13,19 +13,19 @@
             <table class="table table-striped table-hover table-sm" border="0" cellpadding="0">
                 <tbody>
                     <tr>
-                        <td>{{ trans("PrePayment::PaymentMethod.bankAccountOwner") }}</td>
+                        <td>{{ trans("PrePayment::PaymentMethod.bankAccountOwner", [], lang) }}</td>
                         <td>{{ bankAccount["accountOwner"] }}</td>
                     </tr>
                     <tr>
-                        <td>{{ trans("PrePayment::PaymentMethod.bankName") }}</td>
+                        <td>{{ trans("PrePayment::PaymentMethod.bankName", [], lang) }}</td>
                         <td>{{ bankAccount["name"] }}</td>
                     </tr>
                     <tr>
-                        <td>{{ trans("PrePayment::PaymentMethod.bankIban") }}</td>
+                        <td>{{ trans("PrePayment::PaymentMethod.bankIban", [], lang) }}</td>
                         <td>{{ bankAccount["iban"] }}</td>
                     </tr>
                     <tr>
-                        <td>{{ trans("PrePayment::PaymentMethod.bankSwift") }}</td>
+                        <td>{{ trans("PrePayment::PaymentMethod.bankSwift", [], lang) }}</td>
                         <td>{{ bankAccount["swift"] }}</td>
                     </tr>
                 </tbody>

--- a/resources/views/ReinitializePaymentScript.twig
+++ b/resources/views/ReinitializePaymentScript.twig
@@ -28,7 +28,7 @@
     {
         $("#cashinadvanceModal .modal-content").html("Loading ...");
 
-        $.get("/payment/cashinadvance/bankdetails", function(data)
+        $.get("/payment/cashinadvance/bankdetails/{{ lang }}", function(data)
         {
             $('#cashinadvanceModal .modal-content').html(data);
         });

--- a/src/Controllers/CashInAdvanceController.php
+++ b/src/Controllers/CashInAdvanceController.php
@@ -7,8 +7,12 @@ use Plenty\Plugin\Templates\Twig;
 
 class CashInAdvanceController extends Controller
 {
-	public function getBankDetails(Twig $twig)
+	public function getBankDetails(Twig $twig, $lang)
 	{
-		return $twig->render('PrePayment::BankDetailsOverlay');
+	    if ($lang === null || !strlen($lang)) {
+	        $lang = 'de';
+        }
+	    
+		return $twig->render('PrePayment::BankDetailsOverlay', ['lang' => $lang]);
 	}
 }

--- a/src/Providers/CashInAdvanceRouteServiceProvider.php
+++ b/src/Providers/CashInAdvanceRouteServiceProvider.php
@@ -21,7 +21,7 @@ class CashInAdvanceRouteServiceProvider extends RouteServiceProvider
                 $routerApi->put('payment/cashinadvance/settings'                           , ['uses' => 'CashInAdvance\Controllers\SettingsController@saveSettings']);
             });
        
-       $router->get('payment/cashinadvance/bankdetails', 'CashInAdvance\Controllers\CashInAdvanceController@getBankDetails');
+       $router->get('payment/cashinadvance/bankdetails/{lang}', 'CashInAdvance\Controllers\CashInAdvanceController@getBankDetails');
     }
 
 }

--- a/src/Providers/ReinitializePayment/CashInAdvanceReinitializePaymentScript.php
+++ b/src/Providers/ReinitializePayment/CashInAdvanceReinitializePaymentScript.php
@@ -4,18 +4,18 @@ namespace CashInAdvance\Providers\ReinitializePayment;
 
 use Plenty\Plugin\Templates\Twig;
 use CashInAdvance\Helper\CashInAdvanceHelper;
-use CashInAdvance\Services\SessionStorageService;
+use Plenty\Modules\Webshop\Contracts\LocalizationRepositoryContract;
 
 class CashInAdvanceReinitializePaymentScript
 {
-	public function call(Twig $twig, SessionStorageService $sessionStorageService): string
+	public function call(Twig $twig, LocalizationRepositoryContract $localizationRepository): string
 	{
 		/** @var CashInAdvanceHelper $paymentHelper */
 		$paymentHelper = pluginApp(CashInAdvanceHelper::class);
 		$paymentId = $paymentHelper->getCashInAdvanceMopId();
 		return $twig->render('PrePayment::ReinitializePaymentScript', [
 		    'paymentMethodId' => $paymentId,
-            'lang' => $sessionStorageService->getLang()
+            'lang' => $localizationRepository->getLanguage()
         ]);
 	}
 }

--- a/src/Providers/ReinitializePayment/CashInAdvanceReinitializePaymentScript.php
+++ b/src/Providers/ReinitializePayment/CashInAdvanceReinitializePaymentScript.php
@@ -4,14 +4,18 @@ namespace CashInAdvance\Providers\ReinitializePayment;
 
 use Plenty\Plugin\Templates\Twig;
 use CashInAdvance\Helper\CashInAdvanceHelper;
+use CashInAdvance\Services\SessionStorageService;
 
 class CashInAdvanceReinitializePaymentScript
 {
-	public function call(Twig $twig): string
+	public function call(Twig $twig, SessionStorageService $sessionStorageService): string
 	{
 		/** @var CashInAdvanceHelper $paymentHelper */
 		$paymentHelper = pluginApp(CashInAdvanceHelper::class);
 		$paymentId = $paymentHelper->getCashInAdvanceMopId();
-		return $twig->render('PrePayment::ReinitializePaymentScript', ['paymentMethodId' => $paymentId]);
+		return $twig->render('PrePayment::ReinitializePaymentScript', [
+		    'paymentMethodId' => $paymentId,
+            'lang' => $sessionStorageService->getLang()
+        ]);
 	}
 }


### PR DESCRIPTION
When using `$sessionStorageService->getLang()` in `CashInAdvanceController:: getBankDetails`, it was for some reason returning `de` instead of the configured language in the webshop.

https://plentymarkets.kanbanize.com/ctrl_board/50/cards/132699/details/

@plentymarkets/team-order-payment 